### PR TITLE
package.json: add repository data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "node_modules/.bin/gulp test"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com/casetext/chai-fireproof"
+  },
   "author": "Harry Schmidt <goldibex@casetext.com>",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
Hey all - I'm currently working on the Chai website, which is fetching package.json data from our plugins. I noticed your package.json was missing repository metadata - this fixes that :smile: 
